### PR TITLE
Make beaker work with provisioner flow

### DIFF
--- a/library/beaker_provisioner.py
+++ b/library/beaker_provisioner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # coding: utf-8 -*-
 
 # (c) 2016, Ariel Opincaru <aopincar@redhat.com>

--- a/playbooks/provisioner/beaker/main.yml
+++ b/playbooks/provisioner/beaker/main.yml
@@ -13,7 +13,7 @@
         ansible_fqdn="{{ provisioner.hosts.host0.fqdn }}"
         ansible_ssh_host="{{ provisioner.hosts.host0.fqdn }}"
         ansible_ssh_user="{{ provisioner.hosts.host0.remote_user }}"
-        ansible_ssh_pass="{{ provisioner.hosts.host0.remote_pass }}"
+        ansible_ssh_password="{{ provisioner.hosts.host0.remote_pass }}"
 
 - name: Use beaker to provision the machine
   hosts: localhost

--- a/playbooks/provisioner/beaker/main.yml
+++ b/playbooks/provisioner/beaker/main.yml
@@ -26,3 +26,12 @@
           password: "{{ provisioner.hosts.host0.remote_pass }}"
           action: "{{ provisioner.hosts.host0.action }}"
           distro_tree_id: "{{ provisioner.hosts.host0.distro_tree_id }}"
+
+    - name: wait for ssh
+      wait_for:
+          host: "{{ provisioner.hosts.host0.fqdn }}"
+          port: 22
+          search_regex: OpenSSH
+          timeout: 300
+          delay: 600
+          connect_timeout: 30


### PR DESCRIPTION
- provisioning python script should look for python
  in env as InfraRed is run in venv
- fix ansible_password typo
- SSH waiter will be included externally
